### PR TITLE
[Feat] 컬러 에셋 및 Extension 추가

### DIFF
--- a/MOZI/MOZI.xcodeproj/project.pbxproj
+++ b/MOZI/MOZI.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		40CBD6262847E52E00B90BE9 /* ColorAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 40CBD6252847E52E00B90BE9 /* ColorAssets.xcassets */; };
+		40CBD6292847E87100B90BE9 /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CBD6282847E87100B90BE9 /* UIColor+Extension.swift */; };
+		40CBD62B2847E9E100B90BE9 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CBD62A2847E9E100B90BE9 /* Color+Extension.swift */; };
 		4F1ADAE82837873200969E1D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1ADAE72837873200969E1D /* AppDelegate.swift */; };
 		4F1ADAEA2837873200969E1D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1ADAE92837873200969E1D /* SceneDelegate.swift */; };
 		4F1ADAF12837873600969E1D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F1ADAF02837873600969E1D /* Assets.xcassets */; };
@@ -28,6 +31,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		40CBD6252847E52E00B90BE9 /* ColorAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ColorAssets.xcassets; sourceTree = "<group>"; };
+		40CBD6282847E87100B90BE9 /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		40CBD62A2847E9E100B90BE9 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		4F1ADAE42837873200969E1D /* MOZI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MOZI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F1ADAE72837873200969E1D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4F1ADAE92837873200969E1D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -61,6 +67,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		40CBD6272847E86600B90BE9 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				40CBD6282847E87100B90BE9 /* UIColor+Extension.swift */,
+				40CBD62A2847E9E100B90BE9 /* Color+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		4F1ADADB2837873200969E1D = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +117,7 @@
 			children = (
 				4F1ADAFD28378B4300969E1D /* Storyboard */,
 				4F1ADAF02837873600969E1D /* Assets.xcassets */,
+				40CBD6252847E52E00B90BE9 /* ColorAssets.xcassets */,
 				4F1ADAF52837873600969E1D /* Info.plist */,
 			);
 			path = Resource;
@@ -118,6 +134,7 @@
 		4F1ADAFE28378B8F00969E1D /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				40CBD6272847E86600B90BE9 /* Extension */,
 				4F23198B283E215500234D59 /* Literal */,
 			);
 			path = Util;
@@ -339,6 +356,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F1ADAF42837873600969E1D /* LaunchScreen.storyboard in Resources */,
+				40CBD6262847E52E00B90BE9 /* ColorAssets.xcassets in Resources */,
 				4F1ADAF12837873600969E1D /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -372,9 +390,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F1ADB0628378C5E00969E1D /* ApplicationCoordinator.swift in Sources */,
+				40CBD62B2847E9E100B90BE9 /* Color+Extension.swift in Sources */,
 				4F23198F283E218500234D59 /* ImageLiteral.swift in Sources */,
 				4F231998283E5F2100234D59 /* CoordinatorFinishDelegate.swift in Sources */,
 				4F231991283E3B9800234D59 /* DefaultTabBarCoordinator.swift in Sources */,
+				40CBD6292847E87100B90BE9 /* UIColor+Extension.swift in Sources */,
 				4F2319AA283E761400234D59 /* DefaultSettingCoordinator.swift in Sources */,
 				4F2319AD283EA8B700234D59 /* HomeCoordinator.swift in Sources */,
 				4F1ADB0428378BF300969E1D /* Coordinator.swift in Sources */,

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen00.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen00.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xCC",
+          "green" : "0xF4",
+          "red" : "0xE8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen01.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen01.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.370",
+          "blue" : "0x75",
+          "green" : "0xE0",
+          "red" : "0xC0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen02.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/lightGreen02.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.730",
+          "blue" : "0x63",
+          "green" : "0xDE",
+          "red" : "0xB9"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/primary.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x63",
+          "green" : "0xA6",
+          "red" : "0x66"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/primary_strong.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/primary_strong.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2D",
+          "green" : "0x77",
+          "red" : "0x4F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Resource/ColorAssets.xcassets/primary_weak.colorset/Contents.json
+++ b/MOZI/MOZI/Resource/ColorAssets.xcassets/primary_weak.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x7A",
+          "green" : "0xBF",
+          "red" : "0x7D"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MOZI/MOZI/Util/Extension/Color+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/Color+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Color+Extension.swift
+//  MOZI
+//
+//  Created by 한상진 on 2022/06/02.
+//
+
+import SwiftUI
+
+extension Color {
+    static let primaryWeak = Color("primary_weak")
+    static let primary = Color("primary")
+    static let primaryStrong = Color("primary_strong")
+    static let lightGreen00 = Color("lightGreen00")
+    static let lightGreen01 = Color("lightGreen01")
+    static let lightGreen02 = Color("lightGreen02")
+}

--- a/MOZI/MOZI/Util/Extension/UIColor+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/UIColor+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  UIColor+Extension.swift
+//  MOZI
+//
+//  Created by 한상진 on 2022/06/02.
+//
+
+import UIKit
+
+extension UIColor {
+    static let primaryWeak = UIColor(named: "primary_weak") ?? #colorLiteral(red: 0.4901960784, green: 0.7490196078, blue: 0.4784313725, alpha: 1)
+    static let primary = UIColor(named: "primary") ?? #colorLiteral(red: 0.4, green: 0.6509803922, blue: 0.3882352941, alpha: 1)
+    static let primaryStrong = UIColor(named: "primary_strong") ?? #colorLiteral(red: 0.3098039216, green: 0.4666666667, blue: 0.1764705882, alpha: 1)
+    static let lightGreen00 = UIColor(named: "lightGreen00") ?? #colorLiteral(red: 0.9098039216, green: 0.9568627451, blue: 0.8, alpha: 1)
+    static let lightGreen01 = UIColor(named: "lightGreen01") ?? #colorLiteral(red: 0.7529411765, green: 0.8784313725, blue: 0.4588235294, alpha: 0.37)
+    static let lightGreen02 = UIColor(named: "lightGreen02") ?? #colorLiteral(red: 0.7254901961, green: 0.8705882353, blue: 0.3882352941, alpha: 0.73)
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #6 

## 📌 구현/변경 사항 및 이유

- 추후 작업들에서 사용할 컬러 에셋들을 추가했으며, UIKit과 SwiftUI 각각에서 편리하게 사용하기 위해 Extension을 구현했습니다.

## 📌 참고사항

**네이밍**
Figma HexColor -> Name

E8F4CC -> lightGreen00
C0E075(37%) -> lightGreen01
B9De63(73%) -> lightGreen02
7DBF8A -> primaryWeak
66A663 -> primary
4F772D -> primaryStrong