### PR TITLE
[ADD] 프로젝트 폰트 추가

### DIFF
--- a/MOZI/MOZI.xcodeproj/project.pbxproj
+++ b/MOZI/MOZI.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		4F2319B0283EA8C500234D59 /* FriendCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319AF283EA8C500234D59 /* FriendCoordinator.swift */; };
 		4F2319B8283EA91000234D59 /* CommunityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */; };
 		4F2319BA283EA92100234D59 /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B9283EA92100234D59 /* SettingCoordinator.swift */; };
+		4FEBECC3284A78EC0034FBAB /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */; };
+		4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECCA284A83C60034FBAB /* Font+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +56,8 @@
 		4F2319AF283EA8C500234D59 /* FriendCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCoordinator.swift; sourceTree = "<group>"; };
 		4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityCoordinator.swift; sourceTree = "<group>"; };
 		4F2319B9283EA92100234D59 /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
+		4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
+		4FEBECCA284A83C60034FBAB /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,6 +76,8 @@
 			children = (
 				40CBD6282847E87100B90BE9 /* UIColor+Extension.swift */,
 				40CBD62A2847E9E100B90BE9 /* Color+Extension.swift */,
+				4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */,
+				4FEBECCA284A83C60034FBAB /* Font+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -390,10 +396,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F1ADB0628378C5E00969E1D /* ApplicationCoordinator.swift in Sources */,
+				4FEBECC3284A78EC0034FBAB /* UIFont+Extension.swift in Sources */,
 				40CBD62B2847E9E100B90BE9 /* Color+Extension.swift in Sources */,
 				4F23198F283E218500234D59 /* ImageLiteral.swift in Sources */,
 				4F231998283E5F2100234D59 /* CoordinatorFinishDelegate.swift in Sources */,
 				4F231991283E3B9800234D59 /* DefaultTabBarCoordinator.swift in Sources */,
+				4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */,
 				40CBD6292847E87100B90BE9 /* UIColor+Extension.swift in Sources */,
 				4F2319AA283E761400234D59 /* DefaultSettingCoordinator.swift in Sources */,
 				4F2319AD283EA8B700234D59 /* HomeCoordinator.swift in Sources */,

--- a/MOZI/MOZI/Util/Extension/Font+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/Font+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  Font+Extension.swift
+//  MOZI
+//
+//  Created by Noah on 2022/06/04.
+//
+
+import Foundation

--- a/MOZI/MOZI/Util/Extension/Font+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/Font+Extension.swift
@@ -5,4 +5,11 @@
 //  Created by Noah on 2022/06/04.
 //
 
-import Foundation
+import SwiftUI
+import UIKit
+
+extension Font {
+    init(UIFont font: UIFont) {
+        self = Font(font as CTFont)
+    }
+}

--- a/MOZI/MOZI/Util/Extension/UIFont+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/UIFont+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  UIFont+Extension.swift
+//  MOZI
+//
+//  Created by Noah on 2022/06/04.
+//
+
+import Foundation

--- a/MOZI/MOZI/Util/Extension/UIFont+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/UIFont+Extension.swift
@@ -5,4 +5,36 @@
 //  Created by Noah on 2022/06/04.
 //
 
-import Foundation
+import UIKit
+
+extension UIFont {
+    static func appleSDGothicNeoRegular(ofSize fontSize: CGFloat) -> UIFont {
+        let customFont = UIFont(name: "AppleSDGothicNeo-Regular", size: fontSize)
+        let systemFont = UIFont.systemFont(ofSize: fontSize, weight: .regular)
+        return customFont ?? systemFont
+    }
+    
+    static func appleSDGothicNeoLight(ofSize fontSize: CGFloat) -> UIFont {
+        let customFont = UIFont(name: "AppleSDGothicNeo-Light", size: fontSize)
+        let systemFont = UIFont.systemFont(ofSize: fontSize, weight: .light)
+        return customFont ?? systemFont
+    }
+    
+    static func appleSDGothicNeoMedium(ofSize fontSize: CGFloat) -> UIFont {
+        let customFont = UIFont(name: "AppleSDGothicNeo-Medium", size: fontSize)
+        let systemFont = UIFont.systemFont(ofSize: fontSize, weight: .medium)
+        return customFont ?? systemFont
+    }
+    
+    static func appleSDGothicNeoSemiBold(ofSize fontSize: CGFloat) -> UIFont {
+        let customFont = UIFont(name: "AppleSDGothicNeo-SemiBold", size: fontSize)
+        let systemFont = UIFont.systemFont(ofSize: fontSize, weight: .semibold)
+        return customFont ?? systemFont
+    }
+    
+    static func appleSDGothicNeoBold(ofSize fontSize: CGFloat) -> UIFont {
+        let customFont = UIFont(name: "AppleSDGothicNeo-Bold", size: fontSize)
+        let systemFont = UIFont.systemFont(ofSize: fontSize, weight: .bold)
+        return customFont ?? systemFont
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- closed: #11 


## 📌 구현/변경 사항 및 이유
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- 프로젝트에서 사용하는 폰트를 문자열 오류없이 사용할 수 있는 Extension을 추가하였습니다.  
 75373618997b6a1b5ed6a63f250f0c6cfe2ccb2f
- UIFont타입을 이용해 Font 타입을 생성하는 Font 생성자 Extension을 정의했습니다.
b1a9b2b307990f9dba39c3e415d77cac6895bfb9
- 사용하려는 폰트를 불러오지 못한다면 같은 font weight의 systemFont를 사용할 수 있도록 구현하였습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 폰트를 생성할 때 사용되는 argument와 argument label은   
Swift API에서 사용하는 argument와 argument label로 네이밍을 맞추었습니다.

![Screen Shot 2022-06-04 at 3 38 32](https://user-images.githubusercontent.com/63908856/171926167-89ab1adb-164a-479f-86ef-c05e873febff.png)

## 📌 Usage
```swift
// UIFont Use Case
.appleSDGothicNeoBold(ofSize: 33)

// Font Use Case
.font(.init(UIFont: .appleSDGothicNeoBold(ofSize: 33)))
```