### PR TITLE
[FEAT] 로그인 화면 구현 

### DIFF
--- a/MOZI/MOZI.xcodeproj/project.pbxproj
+++ b/MOZI/MOZI.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		4F2319B0283EA8C500234D59 /* FriendCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319AF283EA8C500234D59 /* FriendCoordinator.swift */; };
 		4F2319B8283EA91000234D59 /* CommunityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */; };
 		4F2319BA283EA92100234D59 /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B9283EA92100234D59 /* SettingCoordinator.swift */; };
+		4F770CBF284CE7F500DED57C /* MoziLoginTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CBE284CE7F500DED57C /* MoziLoginTextField.swift */; };
+		4F770CC1284CE89400DED57C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CC0284CE89400DED57C /* LoginView.swift */; };
+		4F770CC3284CE97F00DED57C /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CC2284CE97F00DED57C /* View+Extension.swift */; };
 		4FEBECC3284A78EC0034FBAB /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */; };
 		4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECCA284A83C60034FBAB /* Font+Extension.swift */; };
 /* End PBXBuildFile section */
@@ -56,6 +59,9 @@
 		4F2319AF283EA8C500234D59 /* FriendCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendCoordinator.swift; sourceTree = "<group>"; };
 		4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityCoordinator.swift; sourceTree = "<group>"; };
 		4F2319B9283EA92100234D59 /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
+		4F770CBE284CE7F500DED57C /* MoziLoginTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoziLoginTextField.swift; sourceTree = "<group>"; };
+		4F770CC0284CE89400DED57C /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		4F770CC2284CE97F00DED57C /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		4FEBECCA284A83C60034FBAB /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -78,6 +84,7 @@
 				40CBD62A2847E9E100B90BE9 /* Color+Extension.swift */,
 				4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */,
 				4FEBECCA284A83C60034FBAB /* Font+Extension.swift */,
+				4F770CC2284CE97F00DED57C /* View+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -150,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				4F1ADB0028378BC300969E1D /* Common */,
+				4F770CBB284CE7B900DED57C /* AuthScene */,
 				4F231994283E5AE000234D59 /* HomeScene */,
 				4F23199D283E754300234D59 /* FriendScene */,
 				4F23199E283E755600234D59 /* CommunityScene */,
@@ -302,6 +310,31 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		4F770CBB284CE7B900DED57C /* AuthScene */ = {
+			isa = PBXGroup;
+			children = (
+				4F770CBC284CE7CC00DED57C /* View */,
+			);
+			path = AuthScene;
+			sourceTree = "<group>";
+		};
+		4F770CBC284CE7CC00DED57C /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4F770CBD284CE7DA00DED57C /* Component */,
+				4F770CC0284CE89400DED57C /* LoginView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		4F770CBD284CE7DA00DED57C /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				4F770CBE284CE7F500DED57C /* MoziLoginTextField.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -403,6 +436,8 @@
 				4F231991283E3B9800234D59 /* DefaultTabBarCoordinator.swift in Sources */,
 				4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */,
 				40CBD6292847E87100B90BE9 /* UIColor+Extension.swift in Sources */,
+				4F770CC1284CE89400DED57C /* LoginView.swift in Sources */,
+				4F770CBF284CE7F500DED57C /* MoziLoginTextField.swift in Sources */,
 				4F2319AA283E761400234D59 /* DefaultSettingCoordinator.swift in Sources */,
 				4F2319AD283EA8B700234D59 /* HomeCoordinator.swift in Sources */,
 				4F1ADB0428378BF300969E1D /* Coordinator.swift in Sources */,
@@ -415,6 +450,7 @@
 				4F2319A8283E760A00234D59 /* DefaultCommunityCoordinator.swift in Sources */,
 				4F2319B8283EA91000234D59 /* CommunityCoordinator.swift in Sources */,
 				4F231993283E3D2200234D59 /* TabBarItemLiteral.swift in Sources */,
+				4F770CC3284CE97F00DED57C /* View+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MOZI/MOZI.xcodeproj/project.pbxproj
+++ b/MOZI/MOZI.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		4F2319B8283EA91000234D59 /* CommunityCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */; };
 		4F2319BA283EA92100234D59 /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2319B9283EA92100234D59 /* SettingCoordinator.swift */; };
 		4F770CBF284CE7F500DED57C /* MoziLoginTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CBE284CE7F500DED57C /* MoziLoginTextField.swift */; };
-		4F770CC1284CE89400DED57C /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CC0284CE89400DED57C /* LoginView.swift */; };
+		4F770CC1284CE89400DED57C /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CC0284CE89400DED57C /* SignInView.swift */; };
 		4F770CC3284CE97F00DED57C /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F770CC2284CE97F00DED57C /* View+Extension.swift */; };
 		4FEBECC3284A78EC0034FBAB /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */; };
 		4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBECCA284A83C60034FBAB /* Font+Extension.swift */; };
@@ -60,7 +60,7 @@
 		4F2319B7283EA91000234D59 /* CommunityCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunityCoordinator.swift; sourceTree = "<group>"; };
 		4F2319B9283EA92100234D59 /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		4F770CBE284CE7F500DED57C /* MoziLoginTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoziLoginTextField.swift; sourceTree = "<group>"; };
-		4F770CC0284CE89400DED57C /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		4F770CC0284CE89400DED57C /* SignInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
 		4F770CC2284CE97F00DED57C /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		4FEBECC2284A78EC0034FBAB /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		4FEBECCA284A83C60034FBAB /* Font+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Extension.swift"; sourceTree = "<group>"; };
@@ -322,7 +322,7 @@
 			isa = PBXGroup;
 			children = (
 				4F770CBD284CE7DA00DED57C /* Component */,
-				4F770CC0284CE89400DED57C /* LoginView.swift */,
+				4F770CC0284CE89400DED57C /* SignInView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -436,7 +436,7 @@
 				4F231991283E3B9800234D59 /* DefaultTabBarCoordinator.swift in Sources */,
 				4FEBECCB284A83C60034FBAB /* Font+Extension.swift in Sources */,
 				40CBD6292847E87100B90BE9 /* UIColor+Extension.swift in Sources */,
-				4F770CC1284CE89400DED57C /* LoginView.swift in Sources */,
+				4F770CC1284CE89400DED57C /* SignInView.swift in Sources */,
 				4F770CBF284CE7F500DED57C /* MoziLoginTextField.swift in Sources */,
 				4F2319AA283E761400234D59 /* DefaultSettingCoordinator.swift in Sources */,
 				4F2319AD283EA8B700234D59 /* HomeCoordinator.swift in Sources */,

--- a/MOZI/MOZI/Application/AppDelegate.swift
+++ b/MOZI/MOZI/Application/AppDelegate.swift
@@ -17,8 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     private func setupNavigationBar() {
         UINavigationBar.appearance().isTranslucent = false
-        UINavigationBar.appearance().barTintColor = .primary
-        UINavigationBar.appearance().backgroundColor = .primary
+        UINavigationBar.appearance().barTintColor = .moziPrimary
+        UINavigationBar.appearance().backgroundColor = .moziPrimary
         UINavigationBar.appearance().setBackgroundImage(UIImage(), for: .default)
         UINavigationBar.appearance().shadowImage = UIImage()
         UINavigationBar.appearance().tintColor = .white

--- a/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
@@ -1,0 +1,8 @@
+//
+//  MoziLoginTextField.swift
+//  MOZI
+//
+//  Created by Noah on 2022/06/05.
+//
+
+import Foundation

--- a/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MoziLoginTextFieldStyle: TextFieldStyle {
-    
     @Binding var onEditing: Bool
     
     // swiftlint:disable:next identifier_name

--- a/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/Component/MoziLoginTextField.swift
@@ -5,4 +5,22 @@
 //  Created by Noah on 2022/06/05.
 //
 
-import Foundation
+import SwiftUI
+
+struct MoziLoginTextFieldStyle: TextFieldStyle {
+    
+    @Binding var onEditing: Bool
+    
+    // swiftlint:disable:next identifier_name
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        VStack {
+            configuration
+                .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 15)))
+            Rectangle()
+                .frame(height: 1)
+                .foregroundColor(
+                    onEditing ? .moziPrimary : Color.init(uiColor: .lightGray)
+                )
+        }
+    }
+}

--- a/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
@@ -1,0 +1,20 @@
+//
+//  LoginView.swift
+//  MOZI
+//
+//  Created by Noah on 2022/06/05.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}

--- a/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
@@ -9,7 +9,24 @@ import SwiftUI
 
 struct LoginView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ZStack {
+            Color.moziPrimary
+            VStack(spacing: 0) {
+                TitleLogoView()
+                    .frame(width: UIScreen.main.bounds.width,
+                           height: UIScreen.main.bounds.height * 0.3)
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+struct TitleLogoView: View {
+    var body: some View {
+        HStack(spacing: 11) {
+            Image(uiImage: .load(named: .titleMoziLogoIcon))
+            Image(uiImage: .load(named: .titleMoziLogo))
+        }
     }
 }
 

--- a/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/LoginView.swift
@@ -15,6 +15,22 @@ struct LoginView: View {
                 TitleLogoView()
                     .frame(width: UIScreen.main.bounds.width,
                            height: UIScreen.main.bounds.height * 0.3)
+                InputFrameView()
+                    .overlay(alignment: .topLeading) {
+                        VStack(alignment: .leading) {
+                            Text("Log in")
+                                .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 33)))
+                                .padding(EdgeInsets(top: 45,
+                                                    leading: 26,
+                                                    bottom: 0,
+                                                    trailing: 0))
+                            UserInfoInputView()
+                                .padding(EdgeInsets(top: 0,
+                                                    leading: 16,
+                                                    bottom: 20,
+                                                    trailing: 16))
+                        }
+                    }
             }
         }
         .ignoresSafeArea()
@@ -27,6 +43,149 @@ struct TitleLogoView: View {
             Image(uiImage: .load(named: .titleMoziLogoIcon))
             Image(uiImage: .load(named: .titleMoziLogo))
         }
+    }
+}
+
+struct InputFrameView: View {
+    var body: some View {
+        ZStack {
+            let shape = Rectangle()
+                .cornerRadius(15, corners: .topLeft)
+                .cornerRadius(15, corners: .topRight)
+            shape.foregroundColor(.white)
+                .frame(height: UIScreen.main.bounds.height * 0.7)
+        }
+        
+    }
+}
+
+struct UserInfoInputView: View {
+    
+    @State private var userIdentifier: String
+    @State private var userPassword: String
+    @State var userIdentifierTextFieldOnEditing: Bool
+    @State var userPasswordTextFeildOnEditing: Bool
+    
+    init() {
+        self.userIdentifier = ""
+        self.userPassword = ""
+        self.userIdentifierTextFieldOnEditing = false
+        self.userPasswordTextFeildOnEditing = false
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading) {
+                Text("아이디 (이메일)")
+                    .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 14)))
+                TextField("아이디 (이메일)을 입력해주세요",
+                          text: $userIdentifier,
+                          onEditingChanged: { onEditing in
+                    self.userIdentifierTextFieldOnEditing = onEditing
+                })
+                .textFieldStyle(
+                    MoziLoginTextFieldStyle(
+                        onEditing: self.$userIdentifierTextFieldOnEditing
+                    )
+                )
+                .overlay(alignment: .trailing) {
+                    Image(uiImage: .load(named: .errorIcon))
+                }
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                
+                Text("유효하지 않은 아이디입니다.")
+                    .font(
+                        .init(uiFont: .appleSDGothicNeoLight(ofSize: 12))
+                    )
+                    .foregroundColor(.red)
+                    .padding(EdgeInsets(top: 0,
+                                        leading: 0,
+                                        bottom: 40,
+                                        trailing: 0))
+                
+                Text("비밀번호")
+                    .font(
+                        .init(uiFont: .appleSDGothicNeoBold(ofSize: 14))
+                    )
+                TextField("비밀번호를 입력해주세요",
+                          text: $userPassword,
+                          onEditingChanged: { onEdit in
+                    self.userPasswordTextFeildOnEditing = onEdit
+                })
+                .textFieldStyle(
+                    MoziLoginTextFieldStyle(
+                        onEditing: self.$userPasswordTextFeildOnEditing
+                    )
+                )
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .padding(EdgeInsets(top: 0,
+                                    leading: 0,
+                                    bottom: 40,
+                                    trailing: 0))
+                
+                Button {
+                    print("hi")
+                } label: {
+                    let shape = RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    shape.fill().foregroundColor(.moziPrimaryStrong)
+                        .frame(height: 52)
+                        .overlay(alignment: .center) {
+                            Text("로그인")
+                                .font(
+                                    .init(uiFont: .appleSDGothicNeoBold(ofSize: 16))
+                                )
+                                .foregroundColor(.white)
+                        }
+                }
+                .padding(EdgeInsets(top: 0,
+                                    leading: 0,
+                                    bottom: 20,
+                                    trailing: 0))
+                FindUserInfoButtonView()
+            }
+        }
+    }
+}
+
+struct FindUserInfoButtonView: View {
+    var body: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 33) {
+                Button {
+                    print("hi")
+                } label: {
+                    Text("아이디 | 비밀번호 찾기")
+                        .font(
+                            .init(uiFont: .appleSDGothicNeoMedium(ofSize: 13))
+                        )
+                        .foregroundColor(.gray)
+                }
+                
+                HStack(spacing: 5) {
+                    Text("아직")
+                    Image(uiImage: .load(named: .subtitleMoziLogo))
+                    Text("회원이 아니신가요?")
+                    Button {
+                        print("hi")
+                    } label: {
+                        Text("회원가입")
+                            .font(
+                                .init(uiFont: .appleSDGothicNeoBold(ofSize: 14))
+                            )
+                            .foregroundColor(.moziPrimary)
+                    }
+                    
+                }
+                .font(
+                    .init(uiFont: .appleSDGothicNeoLight(ofSize: 14))
+                )
+            }
+            Spacer()
+        }
+        
     }
 }
 

--- a/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
@@ -126,7 +126,7 @@ struct UserInfoInputView: View {
                                     trailing: 0))
                 
                 Button {
-                    print("hi")
+                    // Action for user when pressed
                 } label: {
                     let shape = RoundedRectangle(cornerRadius: 26, style: .continuous)
                     shape.fill().foregroundColor(.moziPrimaryStrong)
@@ -155,7 +155,7 @@ struct FindUserInfoButtonView: View {
             Spacer()
             VStack(spacing: 33) {
                 Button {
-                    print("hi")
+                    // Action for user when pressed
                 } label: {
                     Text("아이디 | 비밀번호 찾기")
                         .font(
@@ -169,7 +169,7 @@ struct FindUserInfoButtonView: View {
                     Image(uiImage: .load(named: .subtitleMoziLogo))
                     Text("회원이 아니신가요?")
                     Button {
-                        print("hi")
+                        // Action for user when pressed
                     } label: {
                         Text("회원가입")
                             .font(

--- a/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
@@ -63,8 +63,8 @@ struct UserInfoInputView: View {
     
     @State private var userIdentifier: String
     @State private var userPassword: String
-    @State var userIdentifierTextFieldOnEditing: Bool
-    @State var userPasswordTextFeildOnEditing: Bool
+    @State private var userIdentifierTextFieldOnEditing: Bool
+    @State private var userPasswordTextFeildOnEditing: Bool
     
     init() {
         self.userIdentifier = ""

--- a/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
@@ -60,7 +60,6 @@ struct InputFrameView: View {
 }
 
 struct UserInfoInputView: View {
-    
     @State private var userIdentifier: String
     @State private var userPassword: String
     @State private var userIdentifierTextFieldOnEditing: Bool
@@ -95,9 +94,7 @@ struct UserInfoInputView: View {
                 .disableAutocorrection(true)
                 
                 Text("유효하지 않은 아이디입니다.")
-                    .font(
-                        .init(uiFont: .appleSDGothicNeoLight(ofSize: 12))
-                    )
+                    .font(.init(uiFont: .appleSDGothicNeoLight(ofSize: 12)))
                     .foregroundColor(.red)
                     .padding(EdgeInsets(top: 0,
                                         leading: 0,
@@ -105,9 +102,7 @@ struct UserInfoInputView: View {
                                         trailing: 0))
                 
                 Text("비밀번호")
-                    .font(
-                        .init(uiFont: .appleSDGothicNeoBold(ofSize: 14))
-                    )
+                    .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 14)))
                 TextField("비밀번호를 입력해주세요",
                           text: $userPassword,
                           onEditingChanged: { onEdit in
@@ -133,9 +128,7 @@ struct UserInfoInputView: View {
                         .frame(height: 52)
                         .overlay(alignment: .center) {
                             Text("로그인")
-                                .font(
-                                    .init(uiFont: .appleSDGothicNeoBold(ofSize: 16))
-                                )
+                                .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 16)))
                                 .foregroundColor(.white)
                         }
                 }
@@ -158,9 +151,7 @@ struct FindUserInfoButtonView: View {
                     // Action for user when pressed
                 } label: {
                     Text("아이디 | 비밀번호 찾기")
-                        .font(
-                            .init(uiFont: .appleSDGothicNeoMedium(ofSize: 13))
-                        )
+                        .font(.init(uiFont: .appleSDGothicNeoMedium(ofSize: 13)))
                         .foregroundColor(.gray)
                 }
                 
@@ -172,16 +163,12 @@ struct FindUserInfoButtonView: View {
                         // Action for user when pressed
                     } label: {
                         Text("회원가입")
-                            .font(
-                                .init(uiFont: .appleSDGothicNeoBold(ofSize: 14))
-                            )
+                            .font(.init(uiFont: .appleSDGothicNeoBold(ofSize: 14)))
                             .foregroundColor(.moziPrimary)
                     }
                     
                 }
-                .font(
-                    .init(uiFont: .appleSDGothicNeoLight(ofSize: 14))
-                )
+                .font(.init(uiFont: .appleSDGothicNeoLight(ofSize: 14)))
             }
             Spacer()
         }

--- a/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
+++ b/MOZI/MOZI/Presentation/AuthScene/View/SignInView.swift
@@ -1,5 +1,5 @@
 //
-//  LoginView.swift
+//  SignInView.swift
 //  MOZI
 //
 //  Created by Noah on 2022/06/05.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct LoginView: View {
+struct SignInView: View {
     var body: some View {
         ZStack {
             Color.moziPrimary
@@ -189,8 +189,8 @@ struct FindUserInfoButtonView: View {
     }
 }
 
-struct LoginView_Previews: PreviewProvider {
+struct SignInView_Previews: PreviewProvider {
     static var previews: some View {
-        LoginView()
+        SignInView()
     }
 }

--- a/MOZI/MOZI/Util/Extension/Color+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/Color+Extension.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 extension Color {
-    static let primaryWeak = Color("primary_weak")
-    static let primary = Color("primary")
-    static let primaryStrong = Color("primary_strong")
+    static let moziPrimaryWeak = Color("primary_weak")
+    static let moziPrimary = Color("primary")
+    static let moziPrimaryStrong = Color("primary_strong")
     static let lightGreen00 = Color("lightGreen00")
     static let lightGreen01 = Color("lightGreen01")
     static let lightGreen02 = Color("lightGreen02")

--- a/MOZI/MOZI/Util/Extension/Font+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/Font+Extension.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import UIKit
 
 extension Font {
-    init(UIFont font: UIFont) {
+    init(uiFont font: UIFont) {
         self = Font(font as CTFont)
     }
 }

--- a/MOZI/MOZI/Util/Extension/UIColor+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/UIColor+Extension.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 extension UIColor {
-    static let primaryWeak = UIColor(named: "primary_weak") ?? #colorLiteral(red: 0.4901960784, green: 0.7490196078, blue: 0.4784313725, alpha: 1)
-    static let primary = UIColor(named: "primary") ?? #colorLiteral(red: 0.4, green: 0.6509803922, blue: 0.3882352941, alpha: 1)
-    static let primaryStrong = UIColor(named: "primary_strong") ?? #colorLiteral(red: 0.3098039216, green: 0.4666666667, blue: 0.1764705882, alpha: 1)
+    static let moziPrimaryWeak = UIColor(named: "primary_weak") ?? #colorLiteral(red: 0.4901960784, green: 0.7490196078, blue: 0.4784313725, alpha: 1)
+    static let moziPrimary = UIColor(named: "primary") ?? #colorLiteral(red: 0.4, green: 0.6509803922, blue: 0.3882352941, alpha: 1)
+    static let moziPrimaryStrong = UIColor(named: "primary_strong") ?? #colorLiteral(red: 0.3098039216, green: 0.4666666667, blue: 0.1764705882, alpha: 1)
     static let lightGreen00 = UIColor(named: "lightGreen00") ?? #colorLiteral(red: 0.9098039216, green: 0.9568627451, blue: 0.8, alpha: 1)
     static let lightGreen01 = UIColor(named: "lightGreen01") ?? #colorLiteral(red: 0.7529411765, green: 0.8784313725, blue: 0.4588235294, alpha: 0.37)
     static let lightGreen02 = UIColor(named: "lightGreen02") ?? #colorLiteral(red: 0.7254901961, green: 0.8705882353, blue: 0.3882352941, alpha: 0.73)

--- a/MOZI/MOZI/Util/Extension/View+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/View+Extension.swift
@@ -1,0 +1,8 @@
+//
+//  View+Extension.swift
+//  MOZI
+//
+//  Created by Noah on 2022/06/05.
+//
+
+import Foundation

--- a/MOZI/MOZI/Util/Extension/View+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/View+Extension.swift
@@ -14,7 +14,6 @@ extension View {
 }
 
 struct RoundedCorner: Shape {
-
     var radius: CGFloat = .infinity
     var corners: UIRectCorner = .allCorners
 

--- a/MOZI/MOZI/Util/Extension/View+Extension.swift
+++ b/MOZI/MOZI/Util/Extension/View+Extension.swift
@@ -5,4 +5,23 @@
 //  Created by Noah on 2022/06/05.
 //
 
-import Foundation
+import SwiftUI
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect,
+                                byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- closed: #5 

## 📌 구현/변경 사항 및 이유
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
- Login 화면의 UI를 구현하였습니다.
- Swift API와의 통일성을 가져가기 위해 Argument Label을 수정하였습니다.

<img width="746" alt="Screen Shot 2022-06-06 at 17 10 01" src="https://user-images.githubusercontent.com/63908856/172121963-7fd7ef11-97fc-4835-add3-6872f7f11449.png">

**기존**
```swift
extension Font {
    init(UIFont font: UIFont) {
        self = Font(font as CTFont)
    }
}
```
**변경 후**
```swift
extension Font {
    init(uiFont font: uiFont) {
        self = Font(font as CTFont)
    }
}
```


- SwiftUI Color와의 primary 네이밍 중복으로 인해 변수명을 변경하였습니다.
- commit : 84819a00973c673d1afb266ee6dc49c9623eb99f
<img width="525" alt="Screen Shot 2022-06-06 at 17 28 55" src="https://user-images.githubusercontent.com/63908856/172124922-e74ca66e-211e-42dc-85a6-c729d5db48fe.png">


## 📌 참고 사항
<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
ID 유효성 검사 로직은 ViewMode을 구현하며 추가하도록 하겠습니다!
| iPhone 13 mini 	|
|----------------	|
|<img width="375" alt="Screen Shot 2022-06-06 at 17 18 11" src="https://user-images.githubusercontent.com/63908856/172123093-643e134d-2c70-466b-9ab6-b26544d41d98.png">|

